### PR TITLE
Indentation fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@ reports in a consistent manner.</p>
     violation reports. It can do so by delivering the following header to
     define a set of reporting endpoints named "<code>endpoint-1</code>": 
 <pre><a data-link-type="dfn" href="#report-to" id="ref-for-report-to-1">Report-To</a>: { "<a data-link-type="dfn" href="#url" id="ref-for-url-1">url</a>": "https://example.com/reports",
-                    "<a data-link-type="dfn" href="#group" id="ref-for-group-1">group</a>": "endpoint-1",
-                    "<a data-link-type="dfn" href="#max-age" id="ref-for-max-age-1">max-age</a>": 10886400 },
+             "<a data-link-type="dfn" href="#group" id="ref-for-group-1">group</a>": "endpoint-1",
+             "<a data-link-type="dfn" href="#max-age" id="ref-for-max-age-1">max-age</a>": 10886400 },
            { "<a data-link-type="dfn" href="#url" id="ref-for-url-2">url</a>": "https://backup.com/reports",
              "<a data-link-type="dfn" href="#group" id="ref-for-group-2">group</a>": "endpoint-1",
              "<a data-link-type="dfn" href="#max-age" id="ref-for-max-age-2">max-age</a>": 10886400 }
@@ -220,8 +220,8 @@ reports in a consistent manner.</p>
     in order to make the processing scripts simpler. It can do so by delivering
     the following header to define two reporting endpoints: 
 <pre><a data-link-type="dfn" href="#report-to" id="ref-for-report-to-2">Report-To</a>: { "<a data-link-type="dfn" href="#url" id="ref-for-url-3">url</a>": "https://example.com/csp-reports",
-                    "<a data-link-type="dfn" href="#group" id="ref-for-group-3">group</a>": "csp-endpoint",
-                    "<a data-link-type="dfn" href="#max-age" id="ref-for-max-age-3">max-age</a>": 10886400 },
+             "<a data-link-type="dfn" href="#group" id="ref-for-group-3">group</a>": "csp-endpoint",
+             "<a data-link-type="dfn" href="#max-age" id="ref-for-max-age-3">max-age</a>": 10886400 },
            { "<a data-link-type="dfn" href="#url" id="ref-for-url-4">url</a>": "https://example.com/hpkp-reports",
              "<a data-link-type="dfn" href="#group" id="ref-for-group-4">group</a>": "hpkp-endpoint",
              "<a data-link-type="dfn" href="#max-age" id="ref-for-max-age-4">max-age</a>": 10886400 }


### PR DESCRIPTION
While going over the spec, weird indentation in the examples bugged me, so here's a PR that fixes it.

Any reason for having both `master` and `gh-pages` branches? I'm PRing into `gh-pages`, which I hope is OK.
