### PR TITLE
update travis script to fix publishing

### DIFF
--- a/.deploy-output.sh
+++ b/.deploy-output.sh
@@ -14,6 +14,6 @@ git add .
 git commit -m "Built by Travis-CI: $STATUS"
 git status
 
-GH_REPO="@github.com/w3c/html.git"
+GH_REPO="@github.com/wicg/reporting.git"
 FULL_REPO="https://$GH_TOKEN$GH_REPO"
 git push --force --quiet $FULL_REPO master:gh-pages > /dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ before_install:
 install:
 - pip install pygments cssselect html5lib lxml
 - git clone --depth=100 --branch=master https://github.com/tabatkins/bikeshed.git
-  ./bikeshed
-- pushd ./bikeshed
-- git checkout fa5c039ccdbc3d055eded9b14f698414b7d73491
-- popd
 - pip install --editable ./bikeshed
 - bikeshed update
 script: bikeshed -f spec ./index.src.html


### PR DESCRIPTION
fixes #31

@plehegar the current travis job is [failing](https://travis-ci.org/WICG/reporting/builds/146130215) in the setup of bikeshed. its running

`git clone --depth=100 --branch=master https://github.com/tabatkins/bikeshed.git  ./bikeshed`

followed by

`git checkout fa5c039ccdbc3d055eded9b14f698414b7d73491`

But that ref is [512 commits behind master on bikeshed](https://github.com/tabatkins/bikeshed/compare/fa5c039ccdbc3d055eded9b14f698414b7d73491...master). So the `--depth` flag combined with the checkout throws an error.

Since it runs without a problem off of bikeshed master, i'm assuming this was a temporary workaround of some kind?

Lemme know if I am misunderstanding the purpose of pinning a commit