### PR TITLE
Group endpoints by origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/index.html

--- a/index.src.html
+++ b/index.src.html
@@ -4,6 +4,7 @@ Status: CG-DRAFT
 ED: https://wicg.github.io/reporting/
 Shortname: reporting
 Group: wicg
+Editor: Douglas Creager 103120, Google Inc., dcreager@google.com
 Editor: Ilya Grigorik 56102, Google Inc., igrigorik@google.comm
 Editor: Mike West 56384, Google Inc., mkwst@google.com
 Abstract:
@@ -155,12 +156,12 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
     define a set of reporting endpoints named "`endpoint-1`":
 
     <pre>
-      <a>Report-To</a>: { "<a>url</a>": "https://example.com/reports",
-                   "<a>group</a>": "endpoint-1",
-                   "<a>max-age</a>": 10886400 },
-                 { "<a>url</a>": "https://backup.com/reports",
-                   "<a>group</a>": "endpoint-1",
-                   "<a>max-age</a>": 10886400 }
+      <a>Report-To</a>: { "<a>group</a>": "endpoint-1",
+                   "<a>max-age</a>": 10886400,
+                   "<a>endpoints</a>": [
+                     { "<a>url</a>": "https://example.com/reports" },
+                     { "<a>url</a>": "https://backup.com/reports" }
+                   ] }
     </pre>
 
     And the following headers, which direct CSP and HPKP reports to that group:
@@ -178,12 +179,16 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
     the following header to define two reporting endpoints:
 
     <pre>
-      <a>Report-To</a>: { "<a>url</a>": "https://example.com/csp-reports",
-                   "<a>group</a>": "csp-endpoint",
-                   "<a>max-age</a>": 10886400 },
-                 { "<a>url</a>": "https://example.com/hpkp-reports",
-                   "<a>group</a>": "hpkp-endpoint",
-                   "<a>max-age</a>": 10886400 }
+      <a>Report-To</a>: { "<a>group</a>": "csp-endpoint",
+                   "<a>max-age</a>": 10886400,
+                   "<a>endpoints</a>": [
+                     { "<a>url</a>": "https://example.com/csp-reports" }
+                   ] },
+                 { "<a>group</a>": "hpkp-endpoint",
+                   "<a>max-age</a>": 10886400,
+                   "<a>endpoints</a>": [
+                     { "<a>url</a>": "https://example.com/hpkp-reports" }
+                   ] }
     </pre>
 
     And the following headers, which direct CSP and HPKP reports to those named
@@ -199,9 +204,55 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
 <section>
   <h2 id="concept">Concepts</h2>
 
+  <h3 id="concept-client">Clients</h3>
+
+  A <dfn export>client</dfn> represents a particular origin's relationship to
+  a set of <a>endpoints</a>.
+
+  Each <a>client</a> has an <dfn for="client" export attribute>origin</dfn>,
+  which is an <a>origin</a>.
+
+  Each <a>client</a> has an
+  <dfn for="client" export attribute>endpoint-groups</dfn> list, which is a list
+  of <a>endpoint groups</a>, each of which MUST have a distinct
+  {{endpoint group/name}}.  (The algorithm in [[#process-header]] guarantees
+  this by keeping the first entry in a `Report-To` header with a particular
+  name.)
+
+  <h3 id="concept-endpoint-groups">Endpoint groups</h3>
+
+  An <dfn export>endpoint group</dfn> is a set of <a>endpoints</a> that will be
+  used together for backup and failover purposes.
+
+  Each <a>endpoint group</a> has a
+  <dfn for="endpoint group" export attribute>name</dfn>, which is an ASCII
+  string.
+
+  Each <a>endpoint group</a> has an
+  <dfn for="endpoint group" export attribute>endpoints</dfn> list, which is a
+  list of <a>endpoints</a>.
+
+  Each <a>endpoint group</a> has a
+  <dfn for="endpoint group" export attribute>subdomains</dfn> flag, which is
+  either "`include`" or "`exclude`".
+
+  Each <a>endpoint group</a> has a
+  <dfn for="endpoint group" export attribute>ttl</dfn> representing the the
+  number of seconds the group remains valid for an <a>origin</a>.
+
+  Each <a>endpoint group</a> has a
+  <dfn for="endpoint group" export attribute>creation</dfn> which is the
+  timestamp at which the group was added to an <a>origin</a>.
+
+  An <a>endpoint group</a> is
+  <dfn for="endpoint group" id="endpoint-group-expired">expired</dfn> if its
+  {{endpoint group/creation}} plus its {{endpoint group/ttl}} represents a time
+  in the past.
+
   <h3 id="concept-endpoints">Endpoints</h3>
 
-  An <dfn export>endpoint</dfn> is location to which <a>reports</a> may be sent.
+  An <dfn export>endpoint</dfn> is location to which <a>reports</a> for a
+  particular <a>origin</a> may be sent.
 
   Each <a>endpoint</a> has a <dfn for="endpoint" export attribute>url</dfn>,
   which is a {{URL}}.
@@ -215,39 +266,8 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   <dfn for="endpoint" export attribute>retry-after</dfn>, which is either
   `null`, or a timestamp after which delivery should be retried.
 
-  Each <a>endpoint</a> has a <dfn for="endpoint" export attribute>clients</dfn>
-  list, which is a list of <a>clients</a>.
-
-  An <a>endpoint</a> is <dfn for="endpoint" id="endpoint-expired">expired</dfn>
-  if every <a>client</a> in its list of {{endpoint/clients}} is
-  <a for="client">expired</a>.
-
   An <a>endpoint</a> is <dfn for="endpoint">pending</dfn> if its
   {{endpoint/retry-after}} is not `null`, and represents a time in the future.
-
-  <h3 id="concept-client">Clients</h3>
-
-  A <dfn export>client</dfn> represents a particular origin's relationship to
-  an <a>endpoint</a>.
-
-  Each <a>client</a> has an <dfn for="client" export attribute>origin</dfn>,
-  which is an <a>origin</a>.
-
-  Each <a>client</a> has a <dfn for="client" export attribute>subdomains</dfn>
-  flag (which is either "`include`" or "`exclude`").
-
-  Each <a>client</a> has a <dfn for="client" export attribute>group</dfn> which
-  is an ASCII string.
-
-  Each <a>client</a> has a <dfn for="client" export attribute>ttl</dfn>
-  representing the the number of seconds the client remains valid for an
-  <a>endpoint</a>.
-
-  Each <a>client</a> has a <dfn for="client" export attribute>creation</dfn>
-  which is the timestamp at which the client was added to an <a>endpoint</a>.
-
-  A <a>client</a> is <dfn for="client" id="client-expired">expired</dfn> if its
-  {{client/creation}} plus its {{client/ttl}} represents a time in the past.
 
   <h3 id="concept-reports">Reports</h3>
 
@@ -258,8 +278,8 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   which is either `null` or an object which can be serialized into a <a>JSON
   text</a>.
 
-  Each <a>report</a> has an <dfn for="report" export attribute>url</dfn>,
-  which is the address of the `Document` or `Worker` from which the report was
+  Each <a>report</a> has a <dfn for="report" export attribute>url</dfn>, which
+  is the address of the `Document` or `Worker` from which the report was
   generated.
 
   Note: We strip the username, password, and fragment from this serialized URL.
@@ -269,8 +289,8 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   which is an <a>origin</a> representing the report's initiator.
 
   Each <a>report</a> has an <dfn for="report" export attribute>group</dfn>,
-  which is a string representing the {{client/group}} to which this report
-  will be sent.
+  which is a string representing the {{endpoint group/name}} of the
+  <a>origin</a>'s <a>endpoint group</a> that the report will be sent to.
 
   Each <a>report</a> has a <dfn for="report" export attribute>type</dfn>,
   which is a non-empty string specifying the type of data the report contains.
@@ -279,24 +299,24 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   which records the time at which the report was generated, in milliseconds
   since the unix epoch.
 
-  Each <a>report</a> has a <dfn for="report" export attribute>attempts</dfn>,
-  which is a non-negative integer representing the number of times the user
-  agent attempted to deliver the report.
+  Each <a>report</a> has an <dfn for="report" export attribute>attempts</dfn>
+  counter, which is a non-negative integer representing the number of times the
+  user agent attempted to deliver the report.
 
   <h3 id="concept-storage">Storage</h3>
 
   A conformant user agent MUST provide a <dfn>reporting cache</dfn>, which
-  is a storage mechanism that maintains a set of <a>endpoints</a> that websites
-  have instructed the user agent to associate with their <a>origins</a>, and a
-  set of <a>reports</a> which are queued for delivery.
+  is a storage mechanism that maintains a set of <a>endpoint groups</a> that
+  websites have instructed the user agent to associate with their
+  <a>origins</a>, and a set of <a>reports</a> which are queued for delivery.
 
   This storage mechanism is opaque, vendor-specific, and not exposed to the
   web, but it MUST provide the following methods which will be used in the
   algorithms this document defines:
 
-  1.  Insert, update, and remove <a>endpoints</a>.
+  1.  Insert, update, and remove <a>clients</a>.
   2.  Enqueue and dequeue <a>reports</a> for delivery.
-  3.  Retrieve a list of <a>endpoint</a> objects.
+  3.  Retrieve a list of <a>client</a> objects for an <a>origin</a>.
   4.  Retrieve a list of queued <a>report</a> objects.
   5.  Clear the cache.
 </section>
@@ -322,62 +342,74 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   The header's value is interpreted as an array of JSON objects, as described in
   Section 4 of [[HTTP-JFV]].
 
-  Each object in the array defines an <a>endpoint</a> to which reports may be
-  delivered, and will be parsed as defined in [[#parse-header]].
+  Each object in the array defines an <a>endpoint group</a> to which reports may
+  be delivered, and will be parsed as defined in [[#process-header]].
 
-  The following subsections defined the initial set of known members in each
+  The following subsections define the initial set of known members in each
   JSON object the header's value defines. Future versions of this document may
   define additional such members, and user agents MUST ignore unknown members
   when parsing the header.
 
-  <h4 id="url-member">The `url` member</h4>
+  <h4 id="id-member">The `group` member</h4>
+
+  The OPTIONAL <dfn>`group`</dfn> member is a string that associates a
+  {{endpoint group/name}} with the <a>endpoint group</a>. The member's value
+  MUST be a string; any other type will result in a parse error. If no member
+  named "`group`" is present in the object, the <a>endpoint group</a> will be
+  given the {{endpoint group/name}} "`default`".
+
+  <h4 id="include-subdomains-member">The `include-subdomains` member</h4>
+
+  The OPTIONAL <dfn>`include-subdomains`</dfn> member is a boolean that enables
+  this <a>endpoint group</a> for all subdomains of the current <a>origin</a>'s
+  {{URL/host}}.  If no member named "`include-subdomains`" is present in the
+  object, or its value is not "`true`", the <a>endpoint group</a> will not be
+  enabled for subdomains.
+
+  <h4 id="max-age-member">The `max-age` member</h4>
+
+  The REQUIRED <dfn export>`max-age`</dfn> member defines the <a>endpoint
+  group</a>'s lifetime, as a non-negative integer number of seconds. The
+  member's value MUST be a non-negative number; any other type will result in a
+  parse error.
+
+  A value of "`0`" will cause the <a>endpoint group</a> to be removed from the
+  user agent's <a>reporting cache</a>.
+
+  <h4 id="endpoints-member">The `endpoints` member</h4>
+
+  The REQUIRED <dfn export>`endpoints`</dfn> member defines the list of
+  <a>endpoints</a> that belong to this <a>endpoint group</a>. The member's value
+  MUST be an array of JSON objects.
+
+  The following subsections define the initial set of known members in each
+  JSON object in the array. Future versions of this document may define
+  additional such members, and user agents MUST ignore unknown members when
+  parsing the elements of the array.
+
+  <!--
+  Note: If a group resolves to multiple <a>endpoints</a>, the user agent will
+  deliver a particular <a>report</a> to <strong>at most one</strong>
+  <a>endpoint</a> in that group on a best-effort basis.
+  -->
+
+  <h4 id="endpoints-url-member">The `endpoints.url` member</h4>
 
   The REQUIRED <dfn>`url`</dfn> member is a string that defines the location
-  of a reporting endpoint. The member's value MUST be a string; any other type
+  of the <a>endpoint</a>. The member's value MUST be a string; any other type
   will result in a parse error.
 
   Moreover, the URL that the member's value represents MUST be <a>potentially
   trustworthy</a> [[!SECURE-CONTEXTS]]. Non-secure endpoints will be ignored.
-
-  <h4 id="id-member">The `group` member</h4>
-
-  The OPTIONAL <dfn>`group`</dfn> member is a string that associates a name with
-  the reporting endpoint. The member's value MUST be a string; any other type
-  will result in a parse error. If no member named "`group`" is present in the
-  object, the <a>endpoint</a> will be associated with a group named "`default`".
-
-  The group name is not unique and multiple endpoints may use the same name to
-  create a set of reporting endpoints that can be used for backup and failover
-  purposes. If the member is omitted, the endpoint MUST be associated with
-  the "default" group name.
-
-  Note: If a group resolves to multiple <a>endpoints</a>, the user agent will
-  deliver a particular <a>report</a> to <strong>at most one</strong>
-  <a>endpoint</a> in that group on a best-effort basis.
-
-  <h4 id="includesubdomains-member">The `includeSubdomains` member</h4>
-
-  The OPTIONAL <dfn>`includeSubdomains`</dfn> member is a boolean that enables
-  an endpoint for all subdomains of the current <a>origin</a>'s {{URL/host}}.
-  If no member named "`includeSubdomains`" is present in the object, or its
-  value is not "`true`", the endpoint will not be enabled for subdomains.
-
-  <h4 id="max-age-member">The `max-age` member</h4>
-
-  The REQUIRED <dfn export>`max-age`</dfn> member defines the reporting endpoint's
-  lifetime, as a non-negative integer number of seconds. The member's value MUST
-  be a number; any other type will result in a parse error.
-
-  A value of "`0`" will cause the <a>endpoint</a> to be removed from the user
-  agent's <a>reporting cache</a>.
 
   <h3 id="process-header" algorithm>
     Process reporting endpoints for |response| to |request|
   </h3>
 
   Given a <a>response</a> (|response|) and a <a>request</a> (|request|), this
-  algorithm extracts a list of <a>endpoint</a> objects, and updates the
-  <a>reporting cache</a> accordingly.
+  algorithm extracts a list of <a>endpoints</a> and <a>endpoint groups</a> for
+  the request's <a>origin</a>, and updates the <a>reporting cache</a>
+  accordingly.
 
   Note: This algorithm is called from around step 13 of <a>main fetch</a>
   [[FETCH]], and only updates the <a>reporting cache</a> if the |response|
@@ -396,105 +428,83 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
           contain a <a>header</a> whose <a for="header" attribute>name</a> is
           "<a>`Report-To`</a>".
 
-  2.  Let |header| be the <a for="header" attribute>value</a> of the
+  2.  Let |origin| be the <a lt="origin of a url">origin</a> of |response|'s
+      <a for="response" attribute>url</a>.
+
+  3.  Let |header| be the <a for="header" attribute>value</a> of the
       <a>header</a> in |response|'s <a for="response" attribute>header list</a>
       whose name is "<a>`Report-To`</a>".
 
-  3.  Let |origin| be the <a lt="origin of a url">origin</a> of |response|'s
-      <a for="response" attribute>url</a>.
+  4.  Let |list| be the result of executing the algorithm defined in Section 4
+      of [[HTTP-JFV]] on |header|. If that algorithm results in an error, abort
+      these steps.
 
-  4.  Let |tuples| be the result of executing [[#parse-header]] on |header|.
+  5.  Let |groups| be an empty list.
 
-  5.  For each |tuple| in |tuples|:
+  6.  For each |item| in |list|:
 
-      1.  If there exists an <a>endpoint</a> (|endpoint|) in the <a>reporting
-          cache</a> whose {{endpoint/url}} is |tuple|'s {{URL}}:
+      1.  If |item| has no member named "<a>`max-age`</a>", or that member's
+          value is not a number, skip to the next |item|.
 
-          1.  For each |client| in |endpoint|'s {{endpoint/clients}}, delete
-              |client| if |origin| is the same as |client|'s {{client/origin}}.
+      2.  If |item| has no member named "<a>`endpoints`</a>", or that member's
+          value is not an array, skip to the next |item|.
 
-      2.  If |tuple|'s {{client/ttl}} is equal to 0, skip to the next tuple.
+      3.  Let |name| be |item|'s "<a>`group`</a>" member's value if present, and
+          "`default`" otherwise.
 
-      3.  If there does not exist an <a>endpoint</a> (|endpoint|) in the
-          <a>reporting cache</a> whose {{endpoint/url}} is |tuple|'s {{URL}}:
+      4.  If there is already an <a>endpoint group</a> in |groups| whose
+          {{endpoint group/name}} is |name|, skip to the next |item|.
 
-          1.  Let |endpoint| be a new <a>endpoint</a> whose properties are set
+      5.  Let |endpoints| be an empty list.
+
+      6.  For each |endpoint item| in the value of |item|'s "<a>`endpoints`</a>"
+          member:
+
+          1.  If |endpoint item| has no member named "<a>`url`</a>", or that
+              member's value is not a string, skip to the next |endpoint item|.
+
+          2.  Let |endpoint| be a new <a>endpoint</a> whose properties are set
               as follows:
 
               :   {{endpoint/url}}
-              ::  |tuple|'s {{URL}}
+              ::  The result of executing the <a>URL parser</a> on
+                  |endpoint item|'s "<a>`url`</a>" member's value.
               :   {{endpoint/failures}}
               ::  0
               :   {{endpoint/retry-after}}
               ::  `null`
-              :   {{endpoint/clients}}
-              ::  an empty list
 
-          2.  Insert |endpoint| into the <a>reporting cache</a> for |origin|.
+          3.  Add |endpoint| to |endpoints|.
 
-      4.  Let |client| be a new <a>client</a> whose properties are set as follows:
+      7.  Let |group| be a new <a>endpoint group</a> whose properties are
+          set as follows:
 
-          :   {{client/origin}}
-          ::  |origin|
-          :   {{client/subdomains}}
-          ::  |tuple|'s {{client/subdomains}}
-          :   {{client/group}}
-          ::  |tuple|'s {{client/group}}
-          :   {{client/ttl}}
-          ::  |tuple|'s {{client/ttl}}
-          :   {{client/creation}}
-          ::  The current timestamp
-
-      5.  Append |client| to |endpoint|'s {{endpoint/clients}} list.
-
-
-  <h3 id="parse-header" algorithm>
-    Parse reporting endpoint tuples from |value|
-  </h3>
-
-  Given a string (|value|) this algorithm will return a list of tuples
-  containing a {{URL}}, {{client/subdomains}} flag, {{client/ttl}}, and a
-  {{client/group}}. This list will be empty if no valid endpoints could be
-  parsed.
-
-  1.  Let |list| be the result of executing the algorithm defined in Section 4
-      of [[HTTP-JFV]]. If that algorithm results in an error, abort these steps.
-
-  2.  Let |tuples| be an empty list.
-
-  3.  For each |item| in |list|:
-
-      1.  If |item| has no member named "<a>`url`</a>", or that member's value
-          is not a string, skip to the next |item|.
-
-      2.  If |item| has no member named "<a>`max-age`</a>", or that member's
-          value is not a number, skip to the next |item|.
-
-      3.  Let |tuple| be a new tuple containing the following:
-
-          :   "`url`"
-          ::  The result of executing the <a>URL parser</a> on |item|'s
-              "<a>`url`</a>" member's value.
-          :   "`subdomains`"
-          ::  "`Include`" if |item| has a member named
-              "<a>`includeSubdomains`</a>" whose value is `true`, "`Exclude`"
+          :   {{endpoint group/name}}
+          ::  |name|
+          :   {{endpoint group/subdomains}}
+          ::  "`include`" if |item| has a member named
+              "<a>`include-subdomains`</a>" whose value is `true`, "`exclude`"
               otherwise.
-          :   "`ttl`"
+          :   {{endpoint group/ttl}}
           ::  |item|'s "<a>`max-age`</a>" member's value.
-          :   "`group`"
-          ::  |item|'s "<a>`group`</a>" member's value if present, and
-              "`default`" otherwise.
+          :   {{endpoint group/creation}}
+          ::  The current timestamp
+          :   {{endpoint group/endpoints}}
+          ::  |endpoints|
 
-      4.  If |tuple|'s "`url`" is not <a>potentially trustworthy</a>, or
-          |tuple|'s "`ttl`" is a negative number, skip to the next |item|.
+      8.  Add |group| to |groups|.
 
-          Note: User agents SHOULD raise some sort of developer-visible parse
-          error in this case.
+  7.  Let |client| be a new <a>client</a> whose properties are set as follows:
 
-      5.  Append |tuple| to |tuples|.
+      :   {{client/origin}}
+      ::  |origin|
+      :   {{client/endpoint-groups}}
+      ::  |groups|
 
-  4.  Return |tuples|.
-</section>
+  8.  If there is already an entry in the <a>reporting cache</a> for
+      <a>origin</a>, replace it with |client|.  Otherwise, insert |client| into
+      the <a>reporting cache</a> for <a>origin</a>.
+
 
 <!-- Big Text: Reporting -->
 <section>
@@ -554,35 +564,29 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   Note: The user agent MAY reject reports for any reason. This API does not
   guarantee delivery of arbitrary amounts of data, for instance.
 
-  <h3 id="does-endpoint-match-report">
-    Does |endpoint| match |report|?
+  <h3 id="choose-endpoint">
+    Choose an |endpoint| from a |group|
   </h3>
 
-  Given an <a>endpoint</a> (|endpoint|) and a <a>report</a> (|report|), this
-  algorithm returns "`Match`" if |report| should be sent to |endpoint|, and
-  "`Does Not Match`" otherwise:
+  Given an <a>endpoint group</a> (|group|), this algorithm chooses an arbitrary
+  eligible <a>endpoint</a> from the group, if there is one.
 
-  1.  For each |client| in |endpoint|'s {{endpoint/clients}}:
+  1.  If |group| is <a for="endpoint group">expired</a>, return `null`.
 
-      1.  If |client| is <a for="client">expired</a>, skip to the next |client|.
+      Note: In this case, the user agent MAY remove |group| from its
+      <a>client</a>, or it may wait and collect garbage <i lang="fr">en
+      masse</i> at some point in the future as described in [[#gc]].
 
-          Note: In this case, the user agent MAY remove |client| from
-          |endpoint|, or it may wait and collect garbage <i lang="fr">en
-          masse</i> at some point in the future as described in [[#gc]].
+  2.  Return the first |endpoint| in |group|'s {{endpoint group/endpoints}} that
+      is not <a for="endpoint">pending</a>.
 
-      2.  Return "`Match`" if each of the following criteria is met:
+      Note: This ensures that each report is assigned to a single endpoint in
+      the specified group. In order to ensure an even distribution across
+      endpoints, the user agent SHOULD randomize the order in which it walks
+      through endpoints in the group.
 
-          1.  |report|'s {{report/group}} is an <a>ASCII case-insensitive</a>
-              match for |client|'s {{client/group}}
-
-          2.  If |client|'s {{client/subdomains}} is "`exclude`", |report|'s
-              {{report/origin}} is the same as |client|'s {{client/origin}}
-
-              Otherwise, |client|'s {{client/origin}}'s {{URL/host}} is either
-              a <a>superdomain match</a> or a <a>congruent match</a> for
-              |report|'s {{report/origin}}'s {{URL/host}} [[!RFC6797]]
-
-  2.  Return "`Does Not Match`".
+  3.  If there are no <a>endpoints</a> in |group| that aren't
+      <a for="endpoint">pending</a>, return `null`.
 
   <h3 id="send-reports" algorithm>
     Send reports
@@ -598,33 +602,47 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
 
   3.  For each |report| in |reports|:
 
-      1.  For |endpoint| in the <a>reporting cache</a>:
+      1.  Let |origin| be |report|'s {{report/origin}}.
 
-          1.  If |endpoint| is <a for="endpoint">expired</a>, skip to the next
-              |endpoint|.
+      2.  Let |client| be the entry in the <a>reporting cache</a> for
+          |origin|.
 
-              Note: In this case, the user agent MAY remove |endpoint| from the
-              <a>reporting cache</a>, or it may wait and collect garbage
-              <i lang="fr">en masse</i> at some point in the future as described
-              in [[#gc]].
+      3.  If there exists an <a>endpoint group</a> (|group|) in |client|'s
+          {{client/endpoint-groups}} list whose {{endpoint group/name}} is
+          |report|'s {{report/group}}:
 
-          2.  If |endpoint| is <a for="endpoint">pending</a>, skip to the next
-              |endpoint|.
+          1.  Let |endpoint| be the result of executing [[#choose-endpoint]] on
+              |group|.
 
-          3.  If [[#does-endpoint-match-report]] returns "`Match`" when executed
-              upon |endpoint| and |report|:
+          2.  If |endpoint| is a not `null`:
 
               1.  Append |report| to |endpoint map|'s list of reports for
                   |endpoint|.
 
               2.  Skip to the next |report|.
 
-                  Note: This ensures that each report is assigned to a single
-                  endpoint, even if it matches multiple. In order to ensure
-                  an even distribution across endpoints, the user agent SHOULD
-                  randomize the order in which it walks through endpoints.
+      4.  For each |parent origin| that is a <a>superdomain match</a>
+          for |origin| [[!RFC6797]]:
 
-      2.  If we reach this step, the |report| did not match any <a>endpoint</a>
+          1.  Let |client| be the entry in the <a>reporting cache</a> for
+              |parent origin|.
+
+          2.  If there exists an <a>endpoint group</a> (|group|) in |client|'s
+              {{client/endpoint-groups}} list whose {{endpoint group/name}} is
+              |report|'s {{report/group}} <b>and</b> whose {{endpoint
+              group/subdomains}} flag is "`include`":
+
+              1.  Let |endpoint| be the result of executing [[#choose-endpoint]]
+                  on |group|.
+
+              2.  If |endpoint| is an <a>endpoint</a>:
+
+                  1.  Append |report| to |endpoint map|'s list of reports for
+                      |endpoint|.
+
+                  2.  Skip to the next |report|.
+
+      5.  If we reach this step, the |report| did not match any <a>endpoint</a>
           and the user agent MAY remove |report| from the <a>reporting cache</a>
           directly. Depending on load, the user agent MAY instead wait for
           [[#gc]] at some point in the future.
@@ -778,9 +796,9 @@ spec: HTTP-JFV; urlPrefix: https://greenbytes.de/tech/webdav/draft-reschke-http-
   and <a>endpoints</a>, and discard those that are no longer relevant. These
   include:
 
-  *   <a>endpoints</a> which are <a for="endpoint">expired</a>
-  *   <a>endpoints</a> which have not been used in some arbitrary period of time
-      (perhaps a ~week?)
+  *   <a>endpoint groups</a> which are <a for="endpoint group">expired</a>
+  *   <a>endpoint groups</a> which have not been used in some arbitrary period
+      of time (perhaps a ~week?)
   *   <a>endpoints</a> whose {{endpoint/failures}} exceed
       some user-agent-defined threshold (~5 seems reasonable)
   *   <a>reports</a> whose {{report/attempts}} exceed


### PR DESCRIPTION
This is a pretty big change.  It changes the reporting cache so that there's a single "client" entry for each origin.  That client contains a list of "endpoint groups", each of which contains a list of "endpoints". These are the same objects as before, just organized differently.

More importantly, this also changes the format of the JSON array in the `Report-To` header:

  - Each element in the array now describes an endpoint group, not an individual endpoint.

  - The `max-age` and `include-subdomains` properties now belong to endpoint groups, and not to individual endpoints.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/67.html" title="Last updated on Feb 5, 2018, 2:14 PM GMT (211e57a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/reporting/67/70d356a...dcreager:211e57a.html" title="Last updated on Feb 5, 2018, 2:14 PM GMT (211e57a)">Diff</a>