### PR TITLE
Updated deprecation report field names to be underscore-separated.

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -7,9 +7,9 @@ When a web application encounters some error or potential problem it is importan
 ## Enabling reporting ##
 Reporting is enabled by specifying a `Report-To` header in the HTTP response, eg:
 ```http
-Report-To: { "url": "https://example.com/reports", "max-age": 10886400 }
+Report-To: { "url": "https://example.com/reports", "max_age": 10886400 }
 ```
-`max-age` (required) specifies the maximum time (in seconds) to attempt to deliver a report.  The `url` specifies an endpoint which will receive an HTTP `POST` request with JSON-formatted body containing an array of reports, eg:
+`max_age` (required) specifies the maximum time (in seconds) to attempt to deliver a report.  The `url` specifies an endpoint which will receive an HTTP `POST` request with JSON-formatted body containing an array of reports, eg:
 ```http
 POST /reports HTTP/1.1
 Host: example.com
@@ -45,25 +45,25 @@ Deprecations are reports indicating that a browser API or feature has been used 
   "url": "https://example.com/",
   "body": {
     "id": "websql", 
-    "anticipatedRemoval": "1/1/2020", 
+    "anticipated_removal": "1/1/2020", 
     "message": "WebSQL is deprecated and will be removed in Chrome 97 around January 2020",
-    "sourceFile": "https://foo.com/index.js",
-    "lineNumber": 1234,
-    "columnNumber": 42
+    "source_file": "https://foo.com/index.js",
+    "line_number": 1234,
+    "column_number": 42
   }
 }
 ```
 
 The report has the following properties:
 - `id` (required): an implementation-defined string identifying the feature or API that will be removed.  This string can be used for grouping and counting related reports.
-- `anticipatedRemoval`: A date indicating roughly when the browser version without the specified API will be generally available (excluding "beta" or other pre-release channels).  This value should be used to sort or prioritize warnings.  When omitted the deprecation should be considered low priority (removal may not actually occur).  
+- `anticipated_removal`: A date indicating roughly when the browser version without the specified API will be generally available (excluding "beta" or other pre-release channels).  This value should be used to sort or prioritize warnings.  When omitted the deprecation should be considered low priority (removal may not actually occur).  
 - `message`: A developer-readable message with details (typically matching what would be displayed on the developer console).  The message is not guaranteed to be unique for a given `id` (eg. it may contain additional context on how the API was used).
-- `sourceFile`: If known, the file which first used the indicated API
-- `lineNumber`: if known, the line number in `sourceFile` where the indicated API was first used.
-- `columnNumber`: if known, the column number in `sourceFile` where the indicated API was first used.
+- `source_file`: If known, the file which first used the indicated API
+- `line_number`: if known, the line number in `source_file` where the indicated API was first used.
+- `column_number`: if known, the column number in `source_file` where the indicated API was first used.
 
 ### Interventions ###
-An [intervention](https://github.com/WICG/interventions/blob/master/README.md) occurs when a browser decides not to honor a request made by the application (eg. for security, performance or user annoyance reasons).  The report properties are the same as those for deprecations, except for the absense of `anticipatedRemoval`.
+An [intervention](https://github.com/WICG/interventions/blob/master/README.md) occurs when a browser decides not to honor a request made by the application (eg. for security, performance or user annoyance reasons).  The report properties are the same as those for deprecations, except for the absense of `anticipated_removal`.
 
 ```json
 {
@@ -73,9 +73,9 @@ An [intervention](https://github.com/WICG/interventions/blob/master/README.md) o
   "body": {
     "id": "audio-no-gesture", 
     "message": "A request to play audio was blocked because it was not triggered by user activation (such as a click).",
-    "sourceFile": "https://foo.com/index.js",
-    "lineNumber": 1234,
-    "columnNumber": 42
+    "source_file": "https://foo.com/index.js",
+    "line_number": 1234,
+    "column_number": 42
   }
 }
 ```
@@ -89,14 +89,14 @@ A crash report indicates that the user was unable to continue using the page bec
   "age": 10,
   "url": "https://example.com/",
   "body": {
-    "crashId": "c2dd3217-24f5-4bee-b74d-99bd055e7edb",
+    "crash_id": "c2dd3217-24f5-4bee-b74d-99bd055e7edb",
     "type": "oom"
   }
 }
 ```
 
 The report has the following properties:
-- `crashId`: A unique identifier. This identifier will not be meaningful to developers directly, but it can potentially be supplied to the browser vendor for more details.
+- `crash_id`: A unique identifier. This identifier will not be meaningful to developers directly, but it can potentially be supplied to the browser vendor for more details.
 - `type`: A more specific classification of the type of crash that occured. Currently, the only valid type is "oom" (omitted otherwise), indicating an out-of-memory crash.
 
 ## ReportingObserver - Observing reports from JavaScript

--- a/index.src.html
+++ b/index.src.html
@@ -162,7 +162,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
 
     <pre>
       <a>Report-To</a>: { "<a for="ReportTo">group</a>": "endpoint-1",
-                   "<a for="ReportTo">max-age</a>": 10886400,
+                   "<a for="ReportTo">max_age</a>": 10886400,
                    "<a>endpoints</a>": [
                      { "<a for="ReportTo">url</a>": "https://example.com/reports" },
                      { "<a for="ReportTo">url</a>": "https://backup.com/reports" }
@@ -186,17 +186,17 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
     <pre>
       <a>Report-To</a>: { "<a for="ReportTo">url</a>": "https://example.com/csp-reports",
                    "<a for="ReportTo">group</a>": "csp-endpoint",
-                   "<a for="ReportTo">max-age</a>": 10886400 },
+                   "<a for="ReportTo">max_age</a>": 10886400 },
                  { "<a for="ReportTo">url</a>": "https://example.com/hpkp-reports",
                    "<a for="ReportTo">group</a>": "hpkp-endpoint",
-                   "<a for="ReportTo">max-age</a>": 10886400 }
+                   "<a for="ReportTo">max_age</a>": 10886400 }
       <a>Report-To</a>: { "<a for="ReportTo">group</a>": "csp-endpoint",
-                   "<a for="ReportTo">max-age</a>": 10886400,
+                   "<a for="ReportTo">max_age</a>": 10886400,
                    "<a for="ReportTo">endpoints</a>": [
                      { "<a for="ReportTo">url</a>": "https://example.com/csp-reports" }
                    ] },
                  { "<a for="ReportTo">group</a>": "hpkp-endpoint",
-                   "<a for="ReportTo">max-age</a>": 10886400,
+                   "<a for="ReportTo">max_age</a>": 10886400,
                    "<a for="ReportTo">endpoints</a>": [
                      { "<a for="ReportTo">url</a>": "https://example.com/hpkp-reports" }
                    ] }
@@ -274,11 +274,11 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
   to respond to a request.
 
   Each <a>endpoint</a> has a
-  <dfn for="endpoint" export attribute>retry-after</dfn>, which is either
+  <dfn for="endpoint" export attribute>retry_after</dfn>, which is either
   `null`, or a timestamp after which delivery should be retried.
 
   An <a>endpoint</a> is <dfn for="endpoint">pending</dfn> if its
-  {{endpoint/retry-after}} is not `null`, and represents a time in the future.
+  {{endpoint/retry_after}} is not `null`, and represents a time in the future.
 
   <h3 id="concept-report-type">Report Type</h3>
 
@@ -403,9 +403,9 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
   "`include-subdomains`" is present in the object, or its value is not "`true`",
   the <a>endpoint group</a> will not be enabled for subdomains.
 
-  <h4 id="max-age-member">The `max-age` member</h4>
+  <h4 id="max-age-member">The `max_age` member</h4>
 
-  The REQUIRED <dfn for="ReportTo" export>`max-age`</dfn> member defines the <a>endpoint
+  The REQUIRED <dfn for="ReportTo" export>`max_age`</dfn> member defines the <a>endpoint
   group</a>'s lifetime, as a non-negative integer number of seconds. The
   member's value MUST be a non-negative number; any other type will result in a
   parse error.
@@ -480,7 +480,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
 
   6.  For each |item| in |list|:
 
-      1.  If |item| has no member named "<a for="ReportTo">`max-age`</a>", or that member's
+      1.  If |item| has no member named "<a for="ReportTo">`max_age`</a>", or that member's
           value is not a number, skip to the next |item|.
 
       2.  If |item| has no member named "<a>`endpoints`</a>", or that member's
@@ -508,7 +508,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
                   |endpoint item|'s "<a for="ReportTo">`url`</a>" member's value.
               :   {{endpoint/failures}}
               ::  0
-              :   {{endpoint/retry-after}}
+              :   {{endpoint/retry_after}}
               ::  `null`
 
           3.  Add |endpoint| to |endpoints|.
@@ -523,7 +523,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
               "<a>`include-subdomains`</a>" whose value is `true`, "`exclude`"
               otherwise.
           :   {{endpoint group/ttl}}
-          ::  |item|'s "<a for="ReportTo">`max-age`</a>" member's value.
+          ::  |item|'s "<a for="ReportTo">`max_age`</a>" member's value.
           :   {{endpoint group/creation}}
           ::  The current timestamp
           :   {{endpoint group/endpoints}}
@@ -707,7 +707,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
       2.  If |result| is "`Success`":
 
           1.  Set |endpoint|'s {{endpoint/failures}} to 0, and its
-              {{endpoint/retry-after}} to `null`.
+              {{endpoint/retry_after}} to `null`.
 
           2.  Remove each <a>report</a> in |reports| from the <a>reporting
               cache</a>.
@@ -723,7 +723,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
 
           1.  Increment |endpoint|'s {{endpoint/failures}}.
 
-          2.  Set |endpoint|'s {{endpoint/retry-after}} to a point in the future
+          2.  Set |endpoint|'s {{endpoint/retry_after}} to a point in the future
               which the user agent chooses.
 
               Note: We don't specify a particular algorithm here, but user
@@ -1035,14 +1035,14 @@ typedef sequence&lt;Report> ReportList;
   A deprecation report's [=report/body=] contains the following fields:
 
     - <dfn for="Deprecation">id</dfn>: an implementation-defined string
-      identifying the feature or API that will be removed. This string can be used
-      for grouping and counting related reports.
+      identifying the feature or API that will be removed. This string can be
+      used for grouping and counting related reports.
 
-    - <dfn for="Deprecation">anticipatedRemoval</dfn>: A date indicating roughly
-      when the browser version without the specified API will be generally
-      available (excluding "beta" or other pre-release channels). This value
-      should be used to sort or prioritize warnings. If unknown, this field
-      should be set to null, and the deprecation should be considered low
+    - <dfn for="Deprecation">anticipated_removal</dfn>: A date indicating
+      roughly when the browser version without the specified API will be
+      generally available (excluding "beta" or other pre-release channels). This
+      value should be used to sort or prioritize warnings. If unknown, this
+      field should be set to null, and the deprecation should be considered low
       priority (removal may not actually occur).
 
     - <dfn for="Deprecation">message</dfn>: A human-readable string with
@@ -1051,16 +1051,16 @@ typedef sequence&lt;Report> ReportList;
       [=Deprecation/id=] (eg. it may contain additional context on how the API
       was used).
 
-    - <dfn for="Deprecation">sourceFile</dfn>: If known, the file which first
+    - <dfn for="Deprecation">source_file</dfn>: If known, the file which first
       used the indicated API, or null otherwise.
 
-    - <dfn for="Deprecation">lineNumber</dfn>: If known, the line number in
-      [=Deprecation/sourceFile=] where the indicated API was first used, or null
-      otherwise.
+    - <dfn for="Deprecation">line_number</dfn>: If known, the line number in
+      [=Deprecation/source_file=] where the indicated API was first used, or
+      null otherwise.
 
-    - <dfn for="Deprecation">columnNumber</dfn>: If known, the column number in
-      [=Deprecation/sourceFile=] where the indicated API was first used, or null
-      otherwise.
+    - <dfn for="Deprecation">column_number</dfn>: If known, the column number in
+      [=Deprecation/source_file=] where the indicated API was first used, or
+      null otherwise.
 
   Deprecation reports are <a>observable from JavaScript</a>.
 


### PR DESCRIPTION
Changed the JSON field names in the spec and EXPLAINER to be underscore-separated, as per the discussion in #72.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/79.html" title="Last updated on May 16, 2018, 7:11 PM GMT (f566460)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/reporting/79/d46d0f1...paulmeyer90:f566460.html" title="Last updated on May 16, 2018, 7:11 PM GMT (f566460)">Diff</a>