### PR TITLE
Change |buffered| default to false.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -891,7 +891,7 @@ callback ReportingObserverCallback = void (sequence&lt;Report> reports, Reportin
 
 dictionary ReportingObserverOptions {
   sequence&lt;DOMString> types;
-  boolean buffered = true;
+  boolean buffered = false;
 };
 
 typedef sequence&lt;Report> ReportList;


### PR DESCRIPTION
Currently, this option defaults to true in the spec, meaning that by default a ReportingObserver will observe reports generated earlier in the page's lifetime than when it began observing.

My intuition is that this is something that should be explicitly requested (and thus should default to false), since a user would otherwise probably assume that observation starts at the call to observe(). I think this would also be more consistent with PerformanceObserver's |buffered| memeber.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/paulmeyer90/reporting/pull/83.html" title="Last updated on May 18, 2018, 5:33 PM GMT (2c83916)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/reporting/83/d46d0f1...paulmeyer90:2c83916.html" title="Last updated on May 18, 2018, 5:33 PM GMT (2c83916)">Diff</a>