### PR TITLE
Update include-subdomains to use underscore

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -420,12 +420,12 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
   error. If no member named "`group`" is present in the object, the <a>endpoint
   group</a> will be given the {{endpoint group/name}} "`default`".
 
-  <h4 id="include-subdomains-member">The `include-subdomains` member</h4>
+  <h4 id="include-subdomains-member">The `include_subdomains` member</h4>
 
-  The OPTIONAL <dfn for="ReportTo">`include-subdomains`</dfn> member is a
+  The OPTIONAL <dfn for="ReportTo">`include_subdomains`</dfn> member is a
   boolean that enables this <a>endpoint group</a> for all subdomains of the
   current <a spec="html">origin</a>'s {{URL/host}}.  If no member named
-  "`include-subdomains`" is present in the object, or its value is not "`true`",
+  "`include_subdomains`" is present in the object, or its value is not "`true`",
   the <a>endpoint group</a> will not be enabled for subdomains.
 
   <h4 id="max-age-member">The `max_age` member</h4>
@@ -578,7 +578,7 @@ spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/webdriver-spec.html#
           ::  |name|
           :   {{endpoint group/subdomains}}
           ::  "`include`" if |item| has a member named
-              "<a>`include-subdomains`</a>" whose value is
+              "<a for="ReportTo">`include_subdomains`</a>" whose value is
               `true`, "`exclude`" otherwise.
           :   {{endpoint group/ttl}}
           ::  |item|'s "<a for="ReportTo">`max_age`</a>" member's value.


### PR DESCRIPTION
We already did this for `max_age`.  All of our JSON field names should now follow the TAG recommendation to use underscores.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dcreager/reporting/pull/90.html" title="Last updated on Jun 7, 2018, 4:54 PM GMT (ba2217a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/reporting/90/71149a7...dcreager:ba2217a.html" title="Last updated on Jun 7, 2018, 4:54 PM GMT (ba2217a)">Diff</a>