### PR TITLE
Use real User-Agent string in examples

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1265,7 +1265,7 @@ typedef sequence&lt;Report> ReportList;
         "type": "csp",
         "age": 10,
         "url": "https://example.com/vulnerable-page/",
-        "user_agent": "ReportingSpec/1",
+        "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
         "body": {
           "blocked": "https://evil.com/evil.js",
           "directive": "script-src",
@@ -1277,7 +1277,7 @@ typedef sequence&lt;Report> ReportList;
         "type": "hpkp",
         "age": 32,
         "url": "https://www.example.com/",
-        "user_agent": "ReportingSpec/1",
+        "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
         "body": {
           "date-time": "2014-04-06T13:00:50Z",
           "hostname": "www.example.com",
@@ -1299,7 +1299,7 @@ typedef sequence&lt;Report> ReportList;
         "type": "nel",
         "age": 29,
         "url": "https://example.com/thing.js",
-        "user_agent": "ReportingSpec/1",
+        "user_agent": "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
         "body": {
           "referrer": "https://www.example.com/",
           "server-ip": "234.233.232.231",


### PR DESCRIPTION
This uses the User-Agent string for Firefox 60 on Linux.